### PR TITLE
checks localStorage.cart for wrong type

### DIFF
--- a/client/components/main.js
+++ b/client/components/main.js
@@ -14,6 +14,10 @@ import {logout} from '../store'
 const Main = (props) => {
   if(!window.localStorage.cart){
   window.localStorage.cart = JSON.stringify({})
+  }else{
+    if(window.localStorage.cart[0] !== '{'){
+      window.localStorage.cart = JSON.stringify({})
+    }
   }
   const {children, handleClick, isLoggedIn} = props
   return (


### PR DESCRIPTION
### Assignee Tasks

- [ ] added unit tests (or none needed)
- [ ] written relevant docs (or none needed)
- [ ] referenced any relevant issues (or none exist)

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

*Your PR Notes Here*
protects against the case that the user manually sets window.localStorage.cart to something other than '{}'